### PR TITLE
Add macOS wheel support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+Dockerfile
+release.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,5 +30,7 @@ target_include_directories(
     dqcsbeqx PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-target_link_options(dqcsbeqx PUBLIC -lrt)
+if(NOT APPLE)
+  target_link_options(dqcsbeqx PUBLIC -lrt)
+endif()
 target_link_libraries(dqcsbeqx dqcsim qx)

--- a/cmake/qx.cmake
+++ b/cmake/qx.cmake
@@ -53,7 +53,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(CXX "Clang-omp++" PARENT_SCOPE)
+  set(CXX "clang-omp++")
   set(QX_CFLAGS "${QX_CFLAGS} -std=c++11 -Wall -Wfatal-errors -Wno-unused-local-typedef -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -msse4.2 -DUSE_OPENMP -Wno-reorder -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-unused-private-field -Wno-deprecated-register -Wno-unused-function")
 endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 


### PR DESCRIPTION
`python3 setup.py bdist_wheel` builds a `dqcsim_qx-0.0.2-py3-none-macosx_10_15_x86_64.whl` wheel on macOS. The `10_15` may limit users with older versions but they should be able to build wheels from source.